### PR TITLE
Fix DNS forwarding problem when a third-party DNS server is used

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -813,9 +813,18 @@ start_rules() {
 start_mosdns(){
 	killall -q -9 mosdns
 	/usr/bin/mosdns -dir /etc/mosdns/ -c ./config.yaml >/dev/null 2>&1 &
-	sed -i "/list server/d" /etc/config/dhcp
-	uci add_list dhcp.@dnsmasq[0].server='127.0.0.1#5335'
-	uci set dhcp.@dnsmasq[0].noresolv="1"
+	addr="127.0.0.1#5335"
+	OLD_SERVER="$(uci get dhcp.@dnsmasq[0].server 2>/dev/null)"
+	if echo "$OLD_SERVER" | grep "^$addr" >/dev/null 2>&1; then
+		return
+	fi
+	uci delete dhcp.@dnsmasq[0].server 2>/dev/null
+	uci add_list dhcp.@dnsmasq[0].server="$addr"
+	for server in $OLD_SERVER; do
+		[ "$server" = "$addr" ] && continue
+		uci add_list dhcp.@dnsmasq[0].server="$server"
+	done
+	uci set dhcp.@dnsmasq[0].noresolv=1
 	uci commit dhcp
 	/etc/init.d/dnsmasq reload
 	ipset add blacklist 1.1.1.1
@@ -827,8 +836,12 @@ start_mosdns(){
 }
 stop_mosdns(){
 	killall -q -9 mosdns
-	sed -i "/list server/d" /etc/config/dhcp
-	uci set dhcp.@dnsmasq[0].noresolv="0"
+	addr="127.0.0.1#5335"
+	uci del_list dhcp.@dnsmasq[0].server="$addr" 2>/dev/null
+	addrlist="$(uci get dhcp.@dnsmasq[0].server 2>/dev/null)"
+	[ -z "$addrlist" ] && {
+		uci delete dhcp.@dnsmasq[0].noresolv 2>/dev/null
+	}
 	uci commit dhcp
 	/etc/init.d/dnsmasq reload
 	ipset del blacklist 1.1.1.1

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -812,7 +812,7 @@ start_rules() {
 
 start_mosdns(){
 	killall -q -9 mosdns
-	/usr/bin/mosdns -dir /etc/mosdns/ -c ./config.yaml >/dev/null 2>&1 &
+	/usr/bin/mosdns start -c config.yaml -d /etc/mosdns >/dev/null 2>&1 &
 	addr="127.0.0.1#5335"
 	OLD_SERVER="$(uci get dhcp.@dnsmasq[0].server 2>/dev/null)"
 	if echo "$OLD_SERVER" | grep "^$addr" >/dev/null 2>&1; then


### PR DESCRIPTION
If third-party DNS forwarding is enabled during mosDNS resolution, the third-party DNS forwarding is automatically deleted after the SSRP switches to port 5335. As a result, the third-party DNS forwarding is invalid. You need to restart the third-party DNS forwarding.